### PR TITLE
Implement email account verification

### DIFF
--- a/app/index.php
+++ b/app/index.php
@@ -21,6 +21,14 @@ switch ($action) {
         }
         include 'views/register.php';
         break;
+    case 'verify':
+        if (isset($_GET['token'])) {
+            verifyAccount($_GET['token']);
+        } else {
+            setFlashMessage('error', 'Brak tokenu weryfikacyjnego.');
+            header("Location: index.php?action=login");
+        }
+        break;
     case 'login':
         if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             login($_POST['email'], $_POST['password']);

--- a/app/views/login.php
+++ b/app/views/login.php
@@ -72,6 +72,18 @@
                 </div>
             <?php endif; ?>
 
+            <?php
+            $flash = getFlashMessage();
+            if ($flash):
+            ?>
+                <div class="mb-4 p-3 <?php echo $flash['type'] === 'error' ? 'bg-red-50 text-red-600' : 'bg-green-50 text-green-600'; ?> rounded-lg flex items-start">
+                    <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 mr-2 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
+                    </svg>
+                    <div><?php echo htmlspecialchars($flash['message']); ?></div>
+                </div>
+            <?php endif; ?>
+
             <form method="POST" action="index.php?action=login" class="space-y-4">
                 <input type="hidden" name="csrf_token" value="<?php echo htmlspecialchars(generateCsrfToken()); ?>">
                 


### PR DESCRIPTION
## Summary
- add `sendVerificationEmail` and account verification helpers
- require email verification on login
- handle `verify` action in router
- display flash messages on login page

## Testing
- `php -l app/auth.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852d65dc2e4832faab65fd8673657d6